### PR TITLE
Fixed live template descriptions

### DIFF
--- a/src/main/resources/liveTemplates/Latte.xml
+++ b/src/main/resources/liveTemplates/Latte.xml
@@ -1,7 +1,7 @@
 <templateSet group="Latte">
 	<template name="{fore"
 			  value="{foreach $ITERABLE$ as $VAR_VALUE$}&#10;    $END$&#10;{/foreach}"
-			  description="{foreach iterable_expr as $value} …{\foreach}"
+			  description="{foreach iterable_expr as $value} …{/foreach}"
 			  toReformat="true"
 			  toShortenFQNames="true">
 		<variable name="ITERABLE" expression="" defaultValue="" alwaysStopAt="true" />
@@ -12,7 +12,7 @@
 	</template>
 	<template name="{forek"
 			  value="{foreach $ITERABLE$ as $VAR_KEY$ => $VAR_VALUE$}&#10;    $END$&#10;{/foreach}"
-			  description="{foreach iterable_expr as $key => $value} … {\foreach}"
+			  description="{foreach iterable_expr as $key => $value} … {/foreach}"
 			  toReformat="true"
 			  toShortenFQNames="true">
 		<variable name="ITERABLE" expression="" defaultValue="" alwaysStopAt="true" />
@@ -23,7 +23,7 @@
 		</context>
 	</template>
 	<template name="{fori" value="{for $INDEX$ = 0; $INDEX$ &lt; $LIMIT$; $INDEX$++}&#10;    $END$&#10;{/for}"
-			  description="{for i = 0; i &lt; limit; i++} … {\for}"
+			  description="{for i = 0; i &lt; limit; i++} … {/for}"
 			  toReformat="true"
 			  toShortenFQNames="true">
 		<variable name="INDEX" expression="phpSuggestVariableName()" defaultValue="" alwaysStopAt="true" />
@@ -34,7 +34,7 @@
 	</template>
 	<template name="{ife"
 			  value="{if $CONDITION$}&#10;    $MIDDLE$&#10;{else}&#10;    $END$&#10;{/if}"
-			  description="{if condition} … {else} … {\if}"
+			  description="{if condition} … {else} … {/if}"
 			  toReformat="true"
 			  toShortenFQNames="true">
 		<variable name="CONDITION" expression="" defaultValue="" alwaysStopAt="true" />


### PR DESCRIPTION
There was a typo in ending tag `{\` instead of `{/`