### PR TITLE
Changes for 1.1.1-RC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 local.properties
 
 /src/main/gen
-/src/main/java/src/com/jantvrdik/intellij/latte/parser/_LatteLexer.flex
+/src/main/java/com/jantvrdik/intellij/latte/parser/_LatteLexer.flex
 
 /.idea
 /.gradle

--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,16 +1,12 @@
 # Backers
 
 Development of Nette IntelliJ plugins is made possible thanks to these awesome backers!
-You can become one of them by [becoming a Patreon Sponsor](https://www.patreon.com/mesour).
+You can become one of them by [becoming a Sponsor](https://github.com/sponsors/mesour).
 
 Check out all the tiers - higher ones include additional goodies like placing
 the logo of your company in Latte IntelliJ README.
 
-# $30
-
--
-
-# $15
+# $25
 
 -
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,29 @@ Provides support for [Latte](https://github.com/nette/latte) – a template engi
 - Plugin page: [IntelliJ plugin Latte](https://plugins.jetbrains.com/plugin/7457-latte)
 - Forum: [Nette forum](https://forum.nette.org/en/32907-upgrades-in-latte-plugin-for-phpstorm)
 
+
+Installation
+------------
+
+Settings → Plugins → Browse repositories → Find "Latte" → Install Plugin → Restart IDE
+
+
+Sponsors
+------
+
+<a href="https://www.futurerockstars.cz/"><img src="https://i.imgur.com/uqdF6OJ.png" alt="FutureRockstars" width="188" height="86"></a>
+
+Does GitHub already have your 💳? Does Nette plugins save you development time? [Send a couple of 💸 a month my way too.](https://github.com/sponsors/mesour) Thank you!
+
+One-time donations through [PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=GSDRZW9YGPE5G&source=url) are also accepted. To request an invoice, [contact me](mailto:matous.nemec@mesour.com) through e-mail.
+
+
 Supported Features
 ------------------
 
 * Syntax highlighting
 * Code completion for PHP, classic HTML, attribute tags and more
 * Registering custom tags, filters and custom functions
-
-
-Installation
-------------
-
-Settings → Plugins → Browse repositories → Find "Latte" → Install Plugin → Restart IDE
 
 
 Testing EAP versions
@@ -28,14 +39,6 @@ Latte plugin for IntelliJ is downloadable from the JetBrains plugin repository d
 - Here is, how to set up custom release channels in PHPStorm: [Custom release channels](https://plugins.jetbrains.com/docs/marketplace/custom-release-channels.html)
 - You have to add this link: `https://plugins.jetbrains.com/plugins/eap/list` to your Custom plugin repositories
 - After you add the link above, you can refresh your plugins Marketplace and you will see RC versions for Latte plugin
-
-
-Donate
-------
-
-Does GitHub already have your 💳? Does Nette plugins save you development time? [Send a couple of 💸 a month my way too.](https://github.com/sponsors/mesour) Thank you!
-
-One-time donations through [PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=GSDRZW9YGPE5G&source=url) are also accepted. To request an invoice, [contact me](mailto:matous.nemec@mesour.com) through e-mail.
 
 
 Building

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 import org.jetbrains.grammarkit.tasks.*
 
 plugins {
-    id 'org.jetbrains.intellij' version "0.4.20"
-    id "org.jetbrains.grammarkit" version "2020.1"
+    id 'org.jetbrains.intellij' version "0.4.21"
+    id "org.jetbrains.grammarkit" version "2020.2"
 }
 
 sourceSets {
@@ -53,6 +53,7 @@ intellij {
 repositories {
     mavenCentral()
     maven { url = 'https://mvnrepository.com/artifact/org.hamcrest/hamcrest-core' }
+    maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
     flatDir {
         dirs 'libs'
     }
@@ -63,6 +64,7 @@ dependencies {
     compileOnly 'com.intellij.psi:css-openapi'
     compileOnly 'com.intellij.psi:javascript-openapi'
     compileOnly 'org.hamcrest:hamcrest-core:1.3'
+    compileOnly 'com.mesour.intellij:intellij-utils:1.0.0-SNAPSHOT'
     testCompile 'junit:junit:4.13'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ properties.load(project.rootProject.file("local.properties").newDataInputStream(
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-version '1.1.1-RC1'
+version '1.1.1-RC2'
 group 'com.jantvrdik.intellij.latte'
 
 jar {

--- a/docs/en/xmlFilesConfiguration.md
+++ b/docs/en/xmlFilesConfiguration.md
@@ -45,21 +45,21 @@ This is example file content with sample values:
 
 ### &lt;tag&gt; in &lt;tags&gt;
 
-| attribute         | required | default value | possible values                         | Description                          |
-|-------------------|----------|---------------|-----------------------------------------|--------------------------------------|
-| name              | yes      | none          | any string                              | Name for tag                         |
-| type              | yes      | none          | PAIR, UNPAIRED, ATTR_ONLY or AUTO_EMPTY | Type for tag                         |
-| arguments         | no       | ""            | any string                              | Used after code completion as help   |
-| allowedFilters    | no       | false         | true, false                             | Used for inspections and completions |
-| multiLine         | no       | false         | true, false                             | Used after code completion           |
-| deprecatedMessage | no       | ""            | any string                              | Message for deprecated tag           |
+| attribute         | required | default value | possible values                            | Description                          |
+|-------------------|----------|---------------|--------------------------------------------|--------------------------------------|
+| name              | yes      | none          | any string                                 | Name for tag                         |
+| type              | yes      | none          | PAIR, UNPAIRED, UNPAIRED_ATTR or ATTR_ONLY | Type for tag                         |
+| arguments         | no       | ""            | any string                                 | Used after code completion as help   |
+| allowedFilters    | no       | false         | true, false                                | Used for inspections and completions |
+| multiLine         | no       | false         | true, false                                | Used after code completion           |
+| deprecatedMessage | no       | ""            | any string                                 | Message for deprecated tag           |
 
 #### Attribute `type` detail:
 
 - `PAIR` - it means pair tag like `{form}{/form}`
 - `UNPAIRED` - it means unpaired tag like `{varType}`
+- `UNPAIRED_ATTR` - it means tag used only as unpaired tag like `{varType}` or n:attribute, like `n:else`
 - `ATTR_ONLY` - it means tag used only as n:attribute, like `n:class`
-- `AUTO_EMPTY` - it means pair tag which can be used as unpaired like `{label} | {label}{/label}`
 
 #### Attribute `arguments` detail:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion = 2019.3
-phpPluginVersion = 193.5233.102
+ideaVersion = 2020.2
+phpPluginVersion = 202.6397.115
 toolboxPluginVersion = 0.4.6
 annotationPluginVersion = 5.3

--- a/src/main/java/com/jantvrdik/intellij/latte/indexes/stubs/types/LattePhpMethodStubType.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/indexes/stubs/types/LattePhpMethodStubType.java
@@ -15,6 +15,7 @@ import com.jantvrdik.intellij.latte.parser.LatteElementTypes;
 import com.jantvrdik.intellij.latte.psi.LattePhpMethod;
 import com.jantvrdik.intellij.latte.psi.LatteTypes;
 import com.jantvrdik.intellij.latte.psi.impl.LattePhpMethodImpl;
+import com.jantvrdik.intellij.latte.utils.LatteTypesUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -83,7 +84,7 @@ public class LattePhpMethodStubType extends LattePhpTypeStub<LattePhpMethodStub,
     @NotNull
     @Override
     public LattePhpMethodStub createStub(@NotNull LighterAST tree, @NotNull LighterASTNode node, @NotNull StubElement parentStub) {
-        LighterASTNode keyNode = LightTreeUtil.firstChildOfType(tree, node, TokenSet.create(LatteTypes.T_PHP_IDENTIFIER));
+        LighterASTNode keyNode = LightTreeUtil.firstChildOfType(tree, node, LatteTypesUtil.methodTokens);
         String key = intern(tree.getCharTable(), keyNode);
         return new LattePhpMethodStubImpl(parentStub, key);
     }

--- a/src/main/java/com/jantvrdik/intellij/latte/inspections/ClassUsagesInspection.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/inspections/ClassUsagesInspection.java
@@ -38,7 +38,7 @@ public class ClassUsagesInspection extends BaseLocalInspectionTool {
 					String className = ((LattePhpClassReference) element).getClassName();
 					Collection<PhpClass> classes = LattePhpUtil.getClassesByFQN(element.getProject(), className);
 					if (classes.size() == 0) {
-						addError(manager, problems, element, "Undefined class '" + className + "'", isOnTheFly);
+						addProblem(manager, problems, element, "Undefined class '" + className + "'", isOnTheFly);
 
 					} else {
 						for (PhpClass phpClass : classes) {

--- a/src/main/java/com/jantvrdik/intellij/latte/lexer/LatteHighlightingLexer.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/lexer/LatteHighlightingLexer.java
@@ -5,7 +5,8 @@ import com.intellij.lexer.LookAheadLexer;
 import com.intellij.psi.TokenType;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
-import com.jantvrdik.intellij.latte.psi.LatteTypes;
+import static com.jantvrdik.intellij.latte.psi.LatteTypes.*;
+import com.jantvrdik.intellij.latte.utils.LatteTypesUtil;
 
 /**
  * Lexer used for syntax highlighting
@@ -13,9 +14,12 @@ import com.jantvrdik.intellij.latte.psi.LatteTypes;
  * It reuses the simple lexer, changing types of some tokens
  */
 public class LatteHighlightingLexer extends LookAheadLexer {
-	private static final TokenSet WHITESPACES = TokenSet.create(TokenType.WHITE_SPACE, LatteTypes.T_WHITESPACE);
+	private static final TokenSet WHITESPACES = LatteTypesUtil.whitespaceTokens;
 
 	private boolean lastHashTag = false;
+	private IElementType beforeLastToken = null;
+	private IElementType beforeBeforeLastToken = null;
+	private IElementType lastNoWhitespaceToken = null;
 	private IElementType lastToken = null;
 	private Lexer lexer;
 
@@ -26,16 +30,19 @@ public class LatteHighlightingLexer extends LookAheadLexer {
 
 	@Override
 	protected void addToken(int endOffset, IElementType type) {
-		if (lastToken == LatteTypes.T_PHP_NAMESPACE_RESOLUTION && (type == LatteTypes.T_PHP_IDENTIFIER)) {
-			type = LatteTypes.T_PHP_NAMESPACE_REFERENCE;
-		} else if (type == LatteTypes.T_PHP_IDENTIFIER && lastHashTag) {
-			type = LatteTypes.T_BLOCK_NAME;
+		if (lastToken == T_PHP_NAMESPACE_RESOLUTION && (type == T_PHP_IDENTIFIER)) {
+			type = T_PHP_NAMESPACE_REFERENCE;
+		} else if (type == T_PHP_IDENTIFIER && lastHashTag) {
+			type = T_BLOCK_NAME;
 		}
 
 		super.addToken(endOffset, type);
+		beforeBeforeLastToken = WHITESPACES.contains(beforeLastToken) ? beforeBeforeLastToken : beforeLastToken;
+		beforeLastToken = WHITESPACES.contains(lastToken) ? beforeLastToken : lastToken;
+		lastNoWhitespaceToken = WHITESPACES.contains(type) ? lastNoWhitespaceToken : type;
 		lastToken = type;
 		if (!WHITESPACES.contains(type)) {
-			lastHashTag = type == LatteTypes.T_MACRO_ARGS && LatteLookAheadLexer.isCharacterAtCurrentPosition(lexer, '#');
+			lastHashTag = type == T_MACRO_ARGS && LatteLookAheadLexer.isCharacterAtCurrentPosition(lexer, '#');
 		}
 	}
 
@@ -43,34 +50,43 @@ public class LatteHighlightingLexer extends LookAheadLexer {
 	protected void lookAhead(Lexer baseLexer) {
 		IElementType currentToken = baseLexer.getTokenType();
 
-		if (currentToken == LatteTypes.T_PHP_IDENTIFIER) {
-			advanceLexer(baseLexer);
-			currentToken = baseLexer.getTokenType();
-			if (WHITESPACES.contains(currentToken)) {
-				advanceLexer(baseLexer);
-				currentToken = baseLexer.getTokenType();
-			}
+		if (currentToken == T_PHP_IDENTIFIER) {
+			currentToken = getNextTokenType(baseLexer);
 
-			if (currentToken == LatteTypes.T_PHP_LEFT_NORMAL_BRACE) {
-				replaceCachedType(0, LatteTypes.T_PHP_METHOD);
+			if (currentToken == T_PHP_LEFT_NORMAL_BRACE) {
+				replaceCachedType(0, T_PHP_METHOD);
 			} else {
 				super.lookAhead(baseLexer);
 			}
 
-		} else if (currentToken == LatteTypes.T_MACRO_ARGS && LatteLookAheadLexer.isCharacterAtCurrentPosition(baseLexer, '#')) {
-			advanceLexer(baseLexer);
-			currentToken = baseLexer.getTokenType();
-			if (TokenSet.create(TokenType.WHITE_SPACE, LatteTypes.T_WHITESPACE).contains(currentToken)) {
-				advanceLexer(baseLexer);
-				currentToken = baseLexer.getTokenType();
+		} else if (currentToken == T_PHP_NAMESPACE_REFERENCE && lastToken == T_PHP_NAMESPACE_RESOLUTION && beforeLastToken != T_PHP_NEW) {
+			currentToken = getNextTokenType(baseLexer);
+
+			if (currentToken == T_PHP_LEFT_NORMAL_BRACE) {
+				replaceCachedType(0, T_PHP_METHOD);
+			} else {
+				super.lookAhead(baseLexer);
 			}
 
-			if (currentToken == LatteTypes.T_PHP_IDENTIFIER) {
-				replaceCachedType(0, LatteTypes.T_BLOCK_NAME);
+		} else if (currentToken == T_MACRO_ARGS && LatteLookAheadLexer.isCharacterAtCurrentPosition(baseLexer, '#')) {
+			currentToken = getNextTokenType(baseLexer);
+
+			if (currentToken == T_PHP_IDENTIFIER) {
+				replaceCachedType(0, T_BLOCK_NAME);
 			}
 
 		} else {
 			super.lookAhead(baseLexer);
 		}
+	}
+
+	private IElementType getNextTokenType(Lexer baseLexer) {
+		advanceLexer(baseLexer);
+		IElementType currentToken = baseLexer.getTokenType();
+		if (WHITESPACES.contains(currentToken)) {
+			advanceLexer(baseLexer);
+			currentToken = baseLexer.getTokenType();
+		}
+		return currentToken;
 	}
 }

--- a/src/main/java/com/jantvrdik/intellij/latte/lexer/LatteLookAheadLexer.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/lexer/LatteLookAheadLexer.java
@@ -37,10 +37,8 @@ public class LatteLookAheadLexer extends LookAheadLexer {
 		}
 
 		super.addToken(endOffset, type);
-		if (!WHITESPACES.contains(type)) {
-			if (!TAG_TAGS.contains(type)) {
-				lastLinkMacro = wasLinkDestination || ((type == LatteTypes.T_MACRO_NAME || type == LatteTypes.T_HTML_TAG_NATTR_NAME) && isLinkMacro(lexer));
-			}
+		if (!TAG_TAGS.contains(type)) {
+			lastLinkMacro = wasLinkDestination || ((type == LatteTypes.T_MACRO_NAME || type == LatteTypes.T_HTML_TAG_NATTR_NAME) && isLinkMacro(lexer));
 		}
 	}
 

--- a/src/main/java/com/jantvrdik/intellij/latte/lexer/grammars/LattePhpLexer.flex
+++ b/src/main/java/com/jantvrdik/intellij/latte/lexer/grammars/LattePhpLexer.flex
@@ -20,13 +20,24 @@ import static com.jantvrdik.intellij.latte.psi.LatteTypes.*;
 %state CLASS_REFERENCE_TYPE
 
 WHITE_SPACE=[ \t\r\n]+
+
+// numbers
+BIN_NUMBER = [+-]?0[bB][01]+*
+OCT_NUMBER = [+-]?0[oO][1-7][0-7]*
+HEX_NUMBER = [+-]?0[xX][0-9a-fA-F]+
+NUMBER = [+-]?[0-9]+(\.[0-9]+)?([Ee][+-]?[0-9]+)?
+
+// identifiers
 IDENTIFIER=[a-zA-Z_][a-zA-Z0-9_]*
 CLASS_NAME=\\?[a-zA-Z_][a-zA-Z0-9_]*\\[a-zA-Z_][a-zA-Z0-9_\\]* | \\[a-zA-Z_][a-zA-Z0-9_]*
 CONTENT_TYPE=[a-zA-Z\-][a-zA-Z0-9\-]*\/[a-zA-Z\-][a-zA-Z0-9\-\.]*
+
+// keywords
 TYPES=("string" | "int" | "bool" | "object" | "float" | "array" | "callable" | "iterable" | "void")
-KEYWORD=(class | "false" | "true" | "break" | "continue" | "case" | "default" | "die" | "exit" | "do" | "while" | "foreach" | "for" | "function" | "echo" | "print" | "catch" | "finally" | "try" | "instanceof" | "if" | "else" | "elseif" | "endif" | "endforeach" | "endfor" | "endwhile" | "endswitch" | "isset" | "or" | "new" | "switch" | "use")
+KEYWORD=(class | "false" | "true" | "break" | "continue" | "case" | "default" | "die" | "exit" | "do" | "while" | "foreach" | "for" | "function" | "echo" | "print" | "catch" | "finally" | "try" | "instanceof" | "if" | "else" | "elseif" | "endif" | "endforeach" | "endfor" | "endwhile" | "endswitch" | "isset" | "or" | "switch" | "use")
 NULL="null"
 MIXED="mixed"
+NEW="new"
 AS="as"
 
 %%
@@ -163,6 +174,10 @@ AS="as"
         return T_PHP_MIXED;
     }
 
+    {NEW} {
+        return T_PHP_NEW;
+    }
+
     "array" / {WHITE_SPACE}? "(" {
         return T_PHP_ARRAY;
     }
@@ -199,7 +214,7 @@ AS="as"
         return T_PHP_DOUBLE_QUOTE_LEFT;
     }
 
-	[0-9]+ {
+	{NUMBER} | {BIN_NUMBER} | {HEX_NUMBER} | {OCT_NUMBER} {
 		return T_MACRO_ARGS_NUMBER;
 	}
 

--- a/src/main/java/com/jantvrdik/intellij/latte/lexer/grammars/LattePhpLexer.flex
+++ b/src/main/java/com/jantvrdik/intellij/latte/lexer/grammars/LattePhpLexer.flex
@@ -327,7 +327,7 @@ AS="as"
 		return T_PHP_DOUBLE_QUOTE_RIGHT;
 	}
 
-	("\\" [^] | [^\"\\$]) {
+	("\\" [^] | [^\"\\$])+ {
 		return T_MACRO_ARGS_STRING;
 	}
 

--- a/src/main/java/com/jantvrdik/intellij/latte/liveTemplates/AbstractLatteTemplateContext.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/liveTemplates/AbstractLatteTemplateContext.java
@@ -1,0 +1,37 @@
+package com.jantvrdik.intellij.latte.liveTemplates;
+
+import com.intellij.codeInsight.template.TemplateActionContext;
+import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiWhiteSpace;
+import com.intellij.psi.util.PsiUtilCore;
+import com.jetbrains.php.lang.PhpLanguage;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+
+abstract public class AbstractLatteTemplateContext extends TemplateContextType {
+	protected AbstractLatteTemplateContext(@NotNull String id, @NotNull String presentableName) {
+		super(id, presentableName);
+	}
+
+	@Override
+	public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
+		PsiFile file = templateActionContext.getFile();
+		int offset = templateActionContext.getStartOffset();
+		if (PsiUtilCore.getLanguageAtOffset(file, offset).isKindOf(PhpLanguage.INSTANCE)) {
+			PsiElement element = file.findElementAt(offset);
+			if (element instanceof PsiWhiteSpace && offset > 0) {
+				element = file.findElementAt(offset - 1);
+			}
+
+			return element != null && this.isInContext(element);
+		} else {
+			return false;
+		}
+	}
+
+	protected abstract boolean isInContext(@NotNull PsiElement element);
+}

--- a/src/main/java/com/jantvrdik/intellij/latte/liveTemplates/LatteTemplateContext.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/liveTemplates/LatteTemplateContext.java
@@ -1,8 +1,11 @@
 package com.jantvrdik.intellij.latte.liveTemplates;
 
+import com.intellij.codeInsight.template.TemplateActionContext;
 import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class LatteTemplateContext extends TemplateContextType {
 	protected LatteTemplateContext() {
@@ -10,7 +13,12 @@ public class LatteTemplateContext extends TemplateContextType {
 	}
 
 	@Override
-	public boolean isInContext(@NotNull PsiFile file, int offset) {
-		return file.getName().endsWith(".latte");
+	public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
+		return templateActionContext.getFile().getName().endsWith(".latte");
+	}
+
+	@Override
+	public @Nullable TemplateContextType getBaseContextType() {
+		return super.getBaseContextType();
 	}
 }

--- a/src/main/java/com/jantvrdik/intellij/latte/parser/GeneratedParserUtilBase.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/parser/GeneratedParserUtilBase.java
@@ -862,7 +862,7 @@ public class GeneratedParserUtilBase {
 
 		public static void initState(ErrorState state, PsiBuilder builder, IElementType root, TokenSet[] extendsSets) {
 			state.extendsSets = extendsSets;
-			PsiFile file = builder.getUserDataUnprotected(FileContextUtil.CONTAINING_FILE_KEY);
+			PsiFile file = builder.getUserData(FileContextUtil.CONTAINING_FILE_KEY);
 			state.completionState = file == null? null: file.getUserData(COMPLETION_STATE_KEY);
 			Language language = file == null? root.getLanguage() : file.getLanguage();
 			state.caseSensitive = language.isCaseSensitive();

--- a/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParser.bnf
+++ b/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParser.bnf
@@ -121,7 +121,7 @@ htmlTag            ::= <<checkPairHtmlTag true>> (htmlOpenTag htmlTagContainer h
 
 htmlTagContainer     ::= (htmlTag | T_TEXT | macro | (pairMacro | unpairedMacro))*
 
-htmlTagContent         ::= (netteAttr | macro | T_TEXT| (pairMacro | unpairedMacro))*
+htmlTagContent         ::= (netteAttr | macro | T_TEXT | (pairMacro | unpairedMacro))*
 
 htmlOpenTag     ::= T_HTML_OPEN_TAG_OPEN htmlTagContent T_HTML_TAG_CLOSE {
                         pin=1
@@ -164,7 +164,7 @@ phpStaticVariable  ::= T_MACRO_ARGS_VAR phpArrayUsage* {
                         ]
                     }
 
-phpMethod        ::= (T_PHP_IDENTIFIER | phpVariable) T_WHITESPACE? phpArgumentList T_WHITESPACE? phpArrayUsage* {
+phpMethod        ::= (T_PHP_IDENTIFIER | phpVariable | (T_PHP_NAMESPACE_RESOLUTION T_PHP_NAMESPACE_REFERENCE)) T_WHITESPACE? phpArgumentList T_WHITESPACE? phpArrayUsage* {
                         mixin="com.jantvrdik.intellij.latte.psi.impl.elements.LattePhpMethodElementImpl"
                         implements="com.jantvrdik.intellij.latte.psi.elements.LattePhpMethodElement"
                         elementTypeClass="com.jantvrdik.intellij.latte.indexes.stubs.types.LattePhpMethodStubType"
@@ -234,7 +234,7 @@ phpStatement       ::= phpStatementFirstPart phpStatementPart* {
                 methods=[getPhpType isPhpVariableOnly isPhpClassReferenceOnly getLastPhpElement]
                 }
 
-phpStatementFirstPart    ::= phpVariable | phpClassReference | phpMethod {
+phpStatementFirstPart    ::= phpVariable | phpMethod | phpClassReference {
                     methods=[getPhpType getPhpStatement getPrevPhpStatementPart getPhpElement]
                     implements="com.jantvrdik.intellij.latte.psi.elements.LattePhpStatementPartElement"
                 }
@@ -312,14 +312,14 @@ phpArgument    ::= phpPrivateArgument | T_PHP_AS | T_PHP_DOUBLE_ARROW
 
 private
 phpPrivateArgument    ::=  phpString | phpArrayOfVariables | phpTypedArguments | phpStatement | phpTypeElement | T_MACRO_ARGS_NUMBER
-                    | phpArray | phpClassReference | phpDefinition
-                    | phpStatic | phpMethod | phpInBrackets | phpVariable | T_PHP_NULL_MARK | T_PHP_CONTENT_TYPE | T_PHP_OBJECT_OPERATOR
+                    | phpArray | phpDefinition | phpMethod | phpClassReference
+                    | phpStatic | phpInBrackets | phpVariable | T_PHP_NULL_MARK | T_PHP_CONTENT_TYPE | T_PHP_OBJECT_OPERATOR
                     | T_PHP_RELATIONAL_OPERATOR | T_PHP_ASSIGNMENT_OPERATOR | T_PHP_LOGIC_OPERATOR | T_PHP_OPERATOR
                     | T_PHP_ADDITIVE_OPERATOR | T_PHP_BITWISE_OPERATOR | T_PHP_SHIFT_OPERATOR
                     | T_PHP_DOUBLE_COLON | T_PHP_METHOD | T_PHP_TYPE | T_PHP_KEYWORD
                     | T_PHP_CAST | T_PHP_NAMESPACE_RESOLUTION | T_BLOCK_NAME | T_PHP_COLON
                     | T_PHP_CONCATENATION | T_PHP_MULTIPLICATIVE_OPERATORS | T_PHP_UNARY_OPERATOR
-                    | T_PHP_EXPRESSION | T_PHP_NULL | T_PHP_MIXED | T_PHP_LEFT_CURLY_BRACE | T_PHP_RIGHT_CURLY_BRACE
+                    | T_PHP_EXPRESSION | T_PHP_NEW | T_PHP_NULL | T_PHP_MIXED | T_PHP_LEFT_CURLY_BRACE | T_PHP_RIGHT_CURLY_BRACE
                     | macroModifier | T_PHP_IDENTIFIER | T_PHP_MACRO_SEPARATOR | T_PHP_OR_INCLUSIVE | T_PHP_DEFINITION_OPERATOR
 
 phpExpression    ::= (expression | T_MACRO_ARGS)* {

--- a/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParser.bnf
+++ b/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParser.bnf
@@ -21,7 +21,7 @@ root             ::= (structureToken)* autoClosedBlock?
 private
 //macro            ::= macroComment | macroClassic
 macro            ::= macroComment | (
-                                          <<checkPairMacro true>> (<<checkEmptyMacro>> emptyMacro | <<checkAutoClosedMacro>> autoEmptyMacro | pairMacro)
+                                          <<checkPairMacro true>> (pairMacro | emptyMacro)
                                         | <<checkPairMacro false>> unpairedMacro
                                     )
 
@@ -39,10 +39,6 @@ pairMacro        ::= macroOpenTag structureToken* macroCloseTag { //incomplete p
                         }
 
 emptyMacro       ::= emptyMacroTag {
-                            extends=macroClassic
-                        }
-
-autoEmptyMacro       ::= macroOpenTag structureToken* (<<checkAutoClosedEndTag>> macroCloseTag)? {
                             extends=macroClassic
                         }
 

--- a/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParser.bnf
+++ b/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParser.bnf
@@ -34,7 +34,7 @@ macroClassic     ::= macroTag macroTag?{
                      	]
                      }
 
-pairMacro        ::= macroOpenTag structureToken* macroCloseTag { //incomplete pair macro is handled in a annotator
+pairMacro        ::= macroOpenTag structureToken* macroCloseTag? { //incomplete pair macro is handled in a annotator
                             extends=macroClassic
                         }
 
@@ -93,7 +93,8 @@ private
 macroArgs        ::= phpContent
 
 // autoClosedBlock
-autoClosedBlock  ::= &("{block" macroArgs? T_MACRO_MODIFIERS? "}") macroOpenTag structureToken*
+//autoClosedBlock  ::= &("{block" macroContent? "}") macroOpenTag structureToken*
+autoClosedBlock  ::= macroOpenTag structureToken*
 
 
 
@@ -352,7 +353,7 @@ phpDoubleQuotedString ::= T_PHP_DOUBLE_QUOTE_LEFT (T_MACRO_ARGS_STRING | phpVari
 // tokens sets
 private
 structureToken   ::= outerHtml | macro | netteAttr
-                        | (pairMacro | unpairedMacro) // this two (pair | unpaired) are here only for error resolve in annotator
+                          | pairMacro | unpairedMacro // this two (pair | unpaired) are here only for error resolve in annotator
 
 
 private

--- a/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParserUtil.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParserUtil.java
@@ -14,25 +14,37 @@ import static com.jantvrdik.intellij.latte.psi.LatteTypes.*;
  * External rules for LatteParser.
  */
 public class LatteParserUtil extends GeneratedParserUtilBase {
-	private static LatteTagSettings lastMacro = null;
 
 	/**
 	 * Looks for a classic macro a returns true if it finds the macro a and it is pair or unpaired (based on pair parameter).
 	 */
 	public static boolean checkPairMacro(PsiBuilder builder, int level, Parser parser) {
-		boolean pair = parser == LatteParser.TRUE_parser_;
 		if (builder.getTokenType() != T_MACRO_OPEN_TAG_OPEN) return false;
 
 		PsiBuilder.Marker marker = builder.mark();
 		String macroName = getMacroName(builder);
 
+		boolean pair = parser == LatteParser.TRUE_parser_;
 		boolean result;
 
-		LatteTagSettings macro = getTag(builder);
-		if (macro != null && macro.getType() == LatteTagSettings.Type.AUTO_EMPTY) {
-			result = pair == isAutoEmptyPair(macroName, builder);
+		LatteTagSettings tag = getTag(builder);
+		if (tag != null && tag.getType() == LatteTagSettings.Type.AUTO_EMPTY) {
+			result = pair == isPair(macroName, builder);
+		} else if (macroName.equals("_")) {
+			// hard coded rule for macro _ because of dg's poor design decision
+			// macro _ is pair only if it has empty arguments, otherwise it is unpaired
+			// see https://github.com/nette/nette/blob/v2.1.2/Nette/Latte/Macros/CoreMacros.php#L193
+			boolean emptyArgs = true;
+			builder.advanceLexer();
+			while (emptyArgs && nextTokenIsFast(builder, T_MACRO_ARGS, T_MACRO_ARGS_NUMBER, T_MACRO_ARGS_STRING, T_MACRO_ARGS_VAR, T_PHP_METHOD)) {
+				emptyArgs = (builder.getTokenText().trim().length() == 0);
+				builder.advanceLexer();
+			}
+			result = (emptyArgs == pair);
+
+			// all other macros which respect rules
 		} else {
-			result = (macro != null ? (macro.getType() == (pair ? LatteTagSettings.Type.PAIR : LatteTagSettings.Type.UNPAIRED)) : !pair);
+			result = (tag != null ? (tag.getType() == (pair ? LatteTagSettings.Type.PAIR : LatteTagSettings.Type.UNPAIRED)) : !pair);
 		}
 
 		marker.rollbackTo();
@@ -51,73 +63,6 @@ public class LatteParserUtil extends GeneratedParserUtilBase {
 
 		marker.rollbackTo();
 		return result;
-	}
-
-	public static boolean checkAutoClosedMacro(PsiBuilder builder, int level) {
-		PsiBuilder.Marker marker = builder.mark();
-
-		LatteTagSettings macro = getTag(builder);
-
-		marker.rollbackTo();
-
-		if (macro != null && macro.getType() == LatteTagSettings.Type.AUTO_EMPTY) {
-			lastMacro = macro;
-			return true;
-		}
-		return false;
-	}
-
-	public static boolean checkAutoClosedEndTag(PsiBuilder builder, int level) {
-		PsiBuilder.Marker marker = builder.mark();
-
-		String macroName = getMacroName(builder);
-
-		marker.rollbackTo();
-
-		boolean result = false;
-		if (lastMacro != null && lastMacro.getMacroName().equals(macroName)) {
-			result = true;
-		}
-		lastMacro = null;
-
-		return result;
-	}
-
-	public static boolean checkEmptyMacro(PsiBuilder builder, int level)
-	{
-		PsiBuilder.Marker marker = builder.mark();
-		boolean result = false;
-		while (true) {
-			IElementType token = builder.getTokenType();
-			if (token == null) {
-				break;
-			} else if (token == LatteTypes.T_MACRO_TAG_CLOSE) {
-				break;
-			} else if (token == LatteTypes.T_MACRO_TAG_CLOSE_EMPTY) {
-				result = true;
-				break;
-			}
-			builder.advanceLexer();
-		}
-		marker.rollbackTo();
-
-		return result;
-	}
-
-	private static boolean isClosingTagExpected(PsiBuilder builder, String macroName)
-	{
-		IElementType type = builder.getTokenType();
-		Builder.Marker marker = builder.mark();
-		if (type == T_MACRO_CLOSE_TAG_OPEN || isEmptyPair(builder)) {
-			return false;
-		}
-		marker.rollbackTo();
-		LatteTagSettings macro = LatteConfiguration.getInstance(builder.getProject()).getTag(macroName);
-
-		if (macro != null && macro.getType() == LatteTagSettings.Type.AUTO_EMPTY) {
-			return isAutoEmptyPair(macroName, builder);
-		}
-		return macro != null && macro.getType() == LatteTagSettings.Type.PAIR;
 	}
 
 	@NotNull
@@ -154,32 +99,26 @@ public class LatteParserUtil extends GeneratedParserUtilBase {
 		return macroName;
 	}
 
-	private static boolean isAutoEmptyPair(String macroName, PsiBuilder builder)
+	private static boolean isPair(String macroName, PsiBuilder builder)
 	{
 		builder.advanceLexer();
-		if (isEmptyPair(builder)) {
-			return true;
-		}
-		int pairMacrosLevel = 0;
 		IElementType type = builder.getTokenType();
 		while (type != null) {
-			if(type == T_HTML_TAG_NATTR_NAME && ("n:" + macroName).equals(builder.getTokenText())) {
-				return false;
+			if (type == T_MACRO_TAG_CLOSE_EMPTY) {
+				return true;
+			} else if (type == T_MACRO_TAG_CLOSE) {
+				break;
 			}
-			if (nextTokenIsFast(builder, T_MACRO_CLOSE_TAG_OPEN, T_MACRO_OPEN_TAG_OPEN)) {
-				boolean closing = type == T_MACRO_CLOSE_TAG_OPEN;
-				String macroName2 = getMacroName(builder);
-				if (macroName2.equals(macroName)) {
-					return closing;
-				} else if (closing) {
-					if (pairMacrosLevel == 0) {
-						return true;
-					} else {
-						pairMacrosLevel--;
-					}
-				} else if (isClosingTagExpected(builder, macroName2)) {
-					pairMacrosLevel++;
-				}
+			builder.advanceLexer();
+			type = builder.getTokenType();
+		}
+		while (type != null) {
+			if (nextTokenIsFast(builder, T_MACRO_CLOSE_TAG_OPEN, T_MACRO_OPEN_TAG_OPEN) && getMacroName(builder).equals(macroName)) {
+				return type == T_MACRO_CLOSE_TAG_OPEN;
+			} else if(type == T_HTML_TAG_NATTR_NAME && ("n:" + macroName).equals(builder.getTokenText())) {
+				builder.advanceLexer();
+				type = builder.getTokenType();
+				continue;
 			}
 			builder.advanceLexer();
 			type = builder.getTokenType();

--- a/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParserUtil.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/parser/LatteParserUtil.java
@@ -8,13 +8,14 @@ import com.jantvrdik.intellij.latte.settings.LatteTagSettings;
 import com.jantvrdik.intellij.latte.utils.LatteHtmlUtil;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.EnumSet;
+
 import static com.jantvrdik.intellij.latte.psi.LatteTypes.*;
 
 /**
  * External rules for LatteParser.
  */
 public class LatteParserUtil extends GeneratedParserUtilBase {
-
 	/**
 	 * Looks for a classic macro a returns true if it finds the macro a and it is pair or unpaired (based on pair parameter).
 	 */
@@ -44,7 +45,7 @@ public class LatteParserUtil extends GeneratedParserUtilBase {
 
 			// all other macros which respect rules
 		} else {
-			result = (tag != null ? (tag.getType() == (pair ? LatteTagSettings.Type.PAIR : LatteTagSettings.Type.UNPAIRED)) : !pair);
+			result = (tag != null ? (pair ? (LatteTagSettings.Type.PAIR == tag.getType()) : LatteTagSettings.Type.unpairedSet.contains(tag.getType())) : !pair);
 		}
 
 		marker.rollbackTo();

--- a/src/main/java/com/jantvrdik/intellij/latte/psi/LatteFileViewProvider.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/psi/LatteFileViewProvider.java
@@ -77,10 +77,7 @@ public class LatteFileViewProvider extends MultiplePsiFilesPerDocumentFileViewPr
 	}
 
 	private boolean isXml() {
-		if (this.getDocument() == null) {
-			return false;
-		}
-		String text = this.getDocument().getText();
+		String text = getContents().toString();
 		int pos = text.indexOf("\n");
 		if (pos > 0) {
 			text = text.substring(0, pos);

--- a/src/main/java/com/jantvrdik/intellij/latte/psi/impl/LattePsiImplUtil.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/psi/impl/LattePsiImplUtil.java
@@ -120,7 +120,10 @@ public class LattePsiImplUtil {
 			return stub.getMethodName();
 		}
 
-		final PsiElement found = findFirstChildWithType(element, T_PHP_IDENTIFIER);
+		PsiElement found = findFirstChildWithType(element, T_PHP_IDENTIFIER);
+		if (found == null) {
+			found = findFirstChildWithType(element, T_PHP_NAMESPACE_REFERENCE);
+		}
 		return found != null ? found.getText() : null;
 	}
 
@@ -459,20 +462,6 @@ public class LattePsiImplUtil {
 	}
 
 	public static boolean isDefinitionInFor(@NotNull LattePhpVariable element) {
-		LatteNetteAttrValue parentAttr = PsiTreeUtil.getParentOfType(element, LatteNetteAttrValue.class);
-		if (parentAttr != null) {
-			PsiElement nextElement = PsiTreeUtil.skipWhitespacesForward(element);
-			if (nextElement == null || nextElement.getNode().getElementType() != LatteTypes.T_PHP_DEFINITION_OPERATOR) {
-				return false;
-			}
-			PsiElement prevElement = PsiTreeUtil.skipWhitespacesBackward(parentAttr);
-			if (prevElement == null || prevElement.getNode().getElementType() != LatteTypes.T_PHP_DEFINITION_OPERATOR) {
-				return false;
-			}
-
-			prevElement = PsiTreeUtil.skipWhitespacesBackward(prevElement);
-			return prevElement != null && prevElement.getText().equals("n:for");
-		}
 		return LatteUtil.matchParentMacroName(element, "for") && LattePhpVariableUtil.isNextDefinitionOperator(element);
 	}
 

--- a/src/main/java/com/jantvrdik/intellij/latte/psi/impl/elements/LattePhpMethodElementImpl.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/psi/impl/elements/LattePhpMethodElementImpl.java
@@ -16,7 +16,7 @@ public abstract class LattePhpMethodElementImpl extends StubBasedPsiElementBase<
 		super(node);
 	}
 
-	public LattePhpMethodElementImpl(final LattePhpMethodStub stub, final IStubElementType nodeType) {
+	public LattePhpMethodElementImpl(final @NotNull LattePhpMethodStub stub, final IStubElementType nodeType) {
 		super(stub, nodeType);
 	}
 

--- a/src/main/java/com/jantvrdik/intellij/latte/reference/LatteReferenceContributor.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/reference/LatteReferenceContributor.java
@@ -49,11 +49,11 @@ public class LatteReferenceContributor extends PsiReferenceContributor {
 
                         String methodName = ((LattePhpMethod) element).getMethodName();
                         if (methodName != null && methodName.length() > 0) {
+                            int addition = element.getFirstChild().getNode().getElementType() == LatteTypes.T_PHP_NAMESPACE_RESOLUTION ? 1 : 0;
                             return new PsiReference[]{
-                                    new LattePhpMethodReference((LattePhpMethod) element, new TextRange(0, methodName.length()))
+                                    new LattePhpMethodReference((LattePhpMethod) element, new TextRange(0 + addition, methodName.length() + addition))
                             };
                         }
-
                         return PsiReference.EMPTY_ARRAY;
                     }
                 });

--- a/src/main/java/com/jantvrdik/intellij/latte/settings/LatteTagSettings.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/settings/LatteTagSettings.java
@@ -164,6 +164,7 @@ public class LatteTagSettings extends BaseLatteSettings implements Serializable 
 		/** macro is available only as unpaired classic macro, e.g. 'var' or 'link' */
 		UNPAIRED,
 
+		/** macro is available as pair or unpaired classic macro, e.g. 'block' or 'label' */
 		AUTO_EMPTY,
 	}
 

--- a/src/main/java/com/jantvrdik/intellij/latte/settings/LatteTagSettings.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/settings/LatteTagSettings.java
@@ -5,10 +5,7 @@ import com.jantvrdik.intellij.latte.config.LatteConfiguration;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 public class LatteTagSettings extends BaseLatteSettings implements Serializable {
 
@@ -121,6 +118,10 @@ public class LatteTagSettings extends BaseLatteSettings implements Serializable 
 		return deprecated;
 	}
 
+	public boolean isTagBlock() {
+		return getMacroName().equals("block");
+	}
+
 	@Attribute("DeprecatedMessage")
 	public String getDeprecatedMessage() {
 		return deprecatedMessage;
@@ -164,8 +165,13 @@ public class LatteTagSettings extends BaseLatteSettings implements Serializable 
 		/** macro is available only as unpaired classic macro, e.g. 'var' or 'link' */
 		UNPAIRED,
 
+		/** macro is available only as unpaired classic macro, e.g. 'var' or 'link' and as attribute macro without any prefix, e.g. 'n:href' or 'n:class' */
+		UNPAIRED_ATTR,
+
 		/** macro is available as pair or unpaired classic macro, e.g. 'block' or 'label' */
-		AUTO_EMPTY,
+		AUTO_EMPTY;
+
+		final public static EnumSet<Type> unpairedSet = java.util.EnumSet.of(UNPAIRED, UNPAIRED_ATTR);
 	}
 
 	public static boolean isValidType(String type) {

--- a/src/main/java/com/jantvrdik/intellij/latte/utils/LattePhpType.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/utils/LattePhpType.java
@@ -10,7 +10,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class LattePhpType {
-    private static Map<String, LattePhpType> instances = new HashMap<>();
+    private static final Map<String, LattePhpType> instances = new HashMap<>();
 
     final public static LattePhpType MIXED = new LattePhpType("mixed");
     final public static LattePhpType STRING = new LattePhpType("string");
@@ -43,8 +43,8 @@ public class LattePhpType {
     private final List<Integer> mixed = new ArrayList<>();
     private final List<Integer> iterable = new ArrayList<>();
     private final List<Integer> natives = new ArrayList<>();
-    private Map<Integer, List<String>> classes = new HashMap<>();
-    private Map<Integer, LattePhpType> forDepth = new HashMap<>();
+    private final Map<Integer, List<String>> classes = new HashMap<>();
+    private final Map<Integer, LattePhpType> forDepth = new HashMap<>();
 
     @NotNull
     public static LattePhpType create(String type, boolean nullable) {
@@ -321,7 +321,7 @@ public class LattePhpType {
     private static class TypePart {
         int depth = 0;
 
-        private String part;
+        private final String part;
         private boolean isNative = false;
         private boolean isNull = false;
         private boolean isMixed = false;

--- a/src/main/java/com/jantvrdik/intellij/latte/utils/LattePhpVariableUtil.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/utils/LattePhpVariableUtil.java
@@ -136,7 +136,7 @@ public class LattePhpVariableUtil {
         List<PsiElement> otherParts = new ArrayList<>();
         phpContent.acceptChildren(new PsiElementVisitor() {
             @Override
-            public void visitElement(PsiElement element) {
+            public void visitElement(@NotNull PsiElement element) {
                 if (
                         element instanceof LattePhpStatement && ((LattePhpStatement) element).isPhpVariableOnly()
                                 || element instanceof LattePhpArrayOfVariables

--- a/src/main/java/com/jantvrdik/intellij/latte/utils/LatteTypesUtil.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/utils/LatteTypesUtil.java
@@ -21,6 +21,8 @@ public class LatteTypesUtil {
 
     final public static TokenSet whitespaceTokens = TokenSet.create(LatteTypes.T_WHITESPACE, TokenType.WHITE_SPACE);
 
+    final public static TokenSet methodTokens = TokenSet.create(LatteTypes.T_PHP_IDENTIFIER, LatteTypes.T_PHP_NAMESPACE_REFERENCE);
+
     public static String[] getNativeClassConstants() {
         return nativeClassConstants;
     }

--- a/src/main/java/com/jantvrdik/intellij/latte/utils/LatteUtil.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/utils/LatteUtil.java
@@ -77,10 +77,11 @@ public class LatteUtil {
 
     public static boolean matchParentMacroName(@NotNull PsiElement element, @NotNull String name) {
         LatteMacroClassic macroClassic = PsiTreeUtil.getParentOfType(element, LatteMacroClassic.class);
-        if (macroClassic == null) {
-            return false;
+        if (macroClassic != null) {
+            return macroClassic.getOpenTag().getMacroName().equals(name);
         }
-        return macroClassic.getOpenTag().getMacroName().equals(name);
+        LatteNetteAttr netteAttr = PsiTreeUtil.getParentOfType(element, LatteNetteAttr.class);
+        return netteAttr != null && netteAttr.getAttrName().getText().equals("n:" + name);
     }
 
     public static String getSpacesBeforeCaret(@NotNull Editor editor) {
@@ -98,7 +99,11 @@ public class LatteUtil {
                 out.append(letter);
             }
             position = position + 1;
-            letter = fileText.charAt(startOffset - position);
+            int current = startOffset - position;
+            if (current < 0) {
+                break;
+            }
+            letter = fileText.charAt(current);
         }
         return out.reverse().toString();
     }

--- a/src/main/java/com/jantvrdik/intellij/latte/utils/LatteUtil.java
+++ b/src/main/java/com/jantvrdik/intellij/latte/utils/LatteUtil.java
@@ -81,7 +81,11 @@ public class LatteUtil {
             return macroClassic.getOpenTag().getMacroName().equals(name);
         }
         LatteNetteAttr netteAttr = PsiTreeUtil.getParentOfType(element, LatteNetteAttr.class);
-        return netteAttr != null && netteAttr.getAttrName().getText().equals("n:" + name);
+        if (netteAttr == null) {
+            return false;
+        }
+        String attributeName = netteAttr.getAttrName().getText();
+        return attributeName.equals("n:" + name) || attributeName.equals("n:tag-" + name) || attributeName.equals("n:inner-" + name);
     }
 
     public static String getSpacesBeforeCaret(@NotNull Editor editor) {

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -5,6 +5,7 @@
 	<li>added new filters |clamp |sort and custom function clamp()</li>
 	<li>added support for references to core functions with \, e.g. \current()</li>
 	<li>added support for floats, hex, oct, bin and numbers with exponent (issue #123)</li>
+	<li>added support for UNPAIRED_ATTR tags (issue #120)</li>
 	<li>fixed undefined variable problem in n:for loop (issue #98)</li>
 	<li>fixed marked parameters as link (issue #102)</li>
 	<li>fixed bug with nested blocks used as n: attributes (issue #109)</li>

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,5 +1,14 @@
 <html>
-<p>1.1.1</p>
+<p>1.1.2-RC2</p>
+<ul>
+	<li>added support for references to core functions with \, e.g. \current()</li>
+	<li>added support for floats, hex, oct, bin and numbers with exponent (issue #123)</li>
+	<li>fixed undefined variable problem in n:for loop (issue #98)</li>
+	<li>fixed marked parameters as link (issue #102)</li>
+	<li>fixed bug with nested blocks used as n: attributes (issue #109)</li>'
+</ul>
+
+<p>1.1.1-RC1</p>
 <ul>
 	<li>added stub indexes - it improve performance if references are resolved (issue #100)</li>
 	<li>added better support for XML configuration files (references to .latte templates etc.)</li>

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -5,7 +5,10 @@
 	<li>added support for floats, hex, oct, bin and numbers with exponent (issue #123)</li>
 	<li>fixed undefined variable problem in n:for loop (issue #98)</li>
 	<li>fixed marked parameters as link (issue #102)</li>
-	<li>fixed bug with nested blocks used as n: attributes (issue #109)</li>'
+	<li>fixed bug with nested blocks used as n: attributes (issue #109)</li>
+	<li>fixed bug in code formatting for AUTO_EMPTY tags (issue #114, #125, #116)</li>
+	<li>fixed performance bugs (issue #105, 117)</li>
+	<li>fixed bug with double-click behavior in double quoted strings (issue #111)</li>
 </ul>
 
 <p>1.1.1-RC1</p>

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -10,7 +10,7 @@
 	<li>fixed marked parameters as link (issue #102)</li>
 	<li>fixed bug with nested blocks used as n: attributes (issue #109)</li>
 	<li>fixed bug in code formatting for AUTO_EMPTY tags (issue #114, #125, #116)</li>
-	<li>fixed performance bugs (issue #105, 117)</li>
+	<li>fixed performance bugs (issue #105, #117)</li>
 	<li>fixed bug with double-click behavior in double quoted strings (issue #111)</li>
 </ul>
 

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,6 +1,8 @@
 <html>
 <p>1.1.2-RC2</p>
 <ul>
+	<li>added new tags {try} {rollback} {ifchanged} {skipIf}</li>
+	<li>added new filters |clamp |sort and custom function clamp()</li>
 	<li>added support for references to core functions with \, e.g. \current()</li>
 	<li>added support for floats, hex, oct, bin and numbers with exponent (issue #123)</li>
 	<li>fixed undefined variable problem in n:for loop (issue #98)</li>

--- a/src/main/resources/liveTemplates/Latte.xml
+++ b/src/main/resources/liveTemplates/Latte.xml
@@ -24,7 +24,7 @@
 	</template>
 	<template name="{fori" value="{for $INDEX$ = 0; $INDEX$ &lt; $LIMIT$; $INDEX$++}&#10;    $END$&#10;{/for}"
 			  description="{for i = 0; i &lt; limit; i++} … {/for}"
-			  toReformat="true"
+			  toReformat="false"
 			  toShortenFQNames="true">
 		<variable name="INDEX" expression="phpSuggestVariableName()" defaultValue="" alwaysStopAt="true" />
 		<variable name="LIMIT" expression="" defaultValue="" alwaysStopAt="true" />

--- a/src/main/resources/xmlSources/Latte.dtd
+++ b/src/main/resources/xmlSources/Latte.dtd
@@ -8,7 +8,7 @@
 
 <!ELEMENT tag (arguments)?>
 <!ATTLIST tag name CDATA #REQUIRED>
-<!ATTLIST tag type (PAIR|UNPAIRED|ATTR_ONLY|AUTO_EMPTY) #REQUIRED>
+<!ATTLIST tag type (PAIR|UNPAIRED|UNPAIRED_ATTR|ATTR_ONLY) #REQUIRED>
 <!ATTLIST tag allowedFilters (true|false) #IMPLIED>
 <!ATTLIST tag arguments CDATA #IMPLIED>
 <!ATTLIST tag deprecatedMessage CDATA #IMPLIED>

--- a/src/main/resources/xmlSources/Latte.xml
+++ b/src/main/resources/xmlSources/Latte.xml
@@ -12,7 +12,7 @@
 				<argument name="expression" types="PHP_EXPRESSION" validType="string" required="true" />
 			</arguments>
 		</tag>
-		<tag name="block" type="AUTO_EMPTY" allowedFilters="true" multiLine="true">
+		<tag name="block" type="PAIR" allowedFilters="true" multiLine="true">
 			<arguments>
 				<argument name="name" types="PHP_IDENTIFIER,VARIABLE,PHP_EXPRESSION" validType="string" required="true" />
 			</arguments>
@@ -73,7 +73,7 @@
 				<argument name="expression" types="PHP_EXPRESSION" required="true" />
 			</arguments>
 		</tag>
-		<tag name="else" type="UNPAIRED" />
+		<tag name="else" type="UNPAIRED_ATTR" />
 		<tag name="elseif" type="UNPAIRED">
 			<arguments>
 				<argument name="condition" types="PHP_CONDITION" validType="bool" required="true" />

--- a/src/main/resources/xmlSources/Latte.xml
+++ b/src/main/resources/xmlSources/Latte.xml
@@ -29,7 +29,7 @@
 		</tag>
 		<tag name="case" type="UNPAIRED">
 			<arguments>
-				<argument name="condition" types="PHP_CONDITION" validType="bool" required="true" />
+				<argument name="condition" types="PHP_CONDITION" required="true" repeatable="true" />
 			</arguments>
 		</tag>
 		<tag name="catch" type="UNPAIRED">
@@ -150,12 +150,12 @@
 		</tag>
 		<tag name="sep" type="PAIR">
 			<arguments>
-				<argument name="width" types="PHP_IDENTIFIER,PHP_EXPRESSION" validType="int" required="true" />
+				<argument name="width" types="PHP_IDENTIFIER,PHP_EXPRESSION" validType="int" />
 			</arguments>
 		</tag>
 		<tag name="snippet" type="PAIR" multiLine="true">
 			<arguments>
-				<argument name="name" types="PHP_IDENTIFIER,VARIABLE,PHP_EXPRESSION" validType="string" required="true" />
+				<argument name="name" types="PHP_IDENTIFIER,VARIABLE,PHP_EXPRESSION" validType="string" />
 			</arguments>
 		</tag>
 		<tag name="snippetArea" type="PAIR" multiLine="true">
@@ -181,6 +181,17 @@
 			</arguments>
 		</tag>
 		<tag name="try" type="PAIR" />
+		<tag name="rollback" type="UNPAIRED" />
+		<tag name="ifchanged" type="PAIR">
+			<arguments>
+				<argument name="expression" types="PHP_EXPRESSION" required="true" repeatable="true" />
+			</arguments>
+		</tag>
+		<tag name="skipIf" type="UNPAIRED">
+			<arguments>
+				<argument name="condition" types="PHP_CONDITION" validType="bool" required="true" />
+			</arguments>
+		</tag>
 		<tag name="var" type="UNPAIRED">
 			<arguments>
 				<argument name="variable" types="VARIABLE_DEFINITION_EXPRESSION" required="true" repeatable="true" />
@@ -198,7 +209,7 @@
 				<argument name="condition" types="PHP_CONDITION" validType="bool" required="true" />
 			</arguments>
 		</tag>
-		<tag name="widget" type="PAIR">
+		<tag name="embed" type="PAIR" multiLine="true">
 			<arguments>
 				<argument name="file" types="BLOCK_USAGE,PHP_IDENTIFIER,VARIABLE,PHP_EXPRESSION" validType="string" required="true" />
 				<argument name="key-value" types="KEY_VALUE" repeatable="true" />
@@ -225,7 +236,11 @@
 		<filter name="breaklines" description="inserts HTML line breaks before all newlines" />
 		<filter name="reverse" description="reverse an UTF-8 string or array" />
 		<filter name="length" description="returns length of a string or array" />
+		<filter name="sort" description="simply sorts array" />
+		<filter name="reverse" description="array sorted in reverse order (used with |sort)" />
 		<filter name="batch" arguments=":(array, length [, item])" description="returns length of a string or array" insertColons="::" />
+
+		<filter name="clamp" description="returns value clamped to the inclusive range of min and max." insertColons="::" />
 
 		<filter name="lower" description="makes a string lower case" />
 		<filter name="upper" description="makes a string upper case" />
@@ -243,4 +258,7 @@
 		<filter name="nocheck" description="prevents automatic URL sanitization" />
 		<filter name="checkurl" description="sanitizes string for use inside href attribute" />
 	</filters>
+	<functions>
+		<function name="clamp" returnType="int|float" arguments="(int|float $value, int|float $min, int|float $max)" description="clamps value to the inclusive range of min and max" />
+	</functions>
 </latte>

--- a/src/test/java/com/jantvrdik/intellij/latte/lexer/LattePhpLexerTest.java
+++ b/src/test/java/com/jantvrdik/intellij/latte/lexer/LattePhpLexerTest.java
@@ -128,17 +128,16 @@ public class LattePhpLexerTest {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void testString() throws Exception {
+	public void testSingleQuotedString() throws Exception {
 		Lexer lexer = new LatteLexer();
-		lexer.start("{= \"te\"}");
+		lexer.start("{= 'te$var'}");
 		assertTokens(lexer, new Pair[] {
 			Pair.create(T_MACRO_OPEN_TAG_OPEN, "{"),
 			Pair.create(T_MACRO_SHORTNAME, "="),
 			Pair.create(T_WHITESPACE, " "),
-			Pair.create(T_PHP_DOUBLE_QUOTE_LEFT, "\""),
-			Pair.create(T_MACRO_ARGS_STRING, "t"),
-			Pair.create(T_MACRO_ARGS_STRING, "e"),
-			Pair.create(T_PHP_DOUBLE_QUOTE_RIGHT, "\""),
+			Pair.create(T_PHP_SINGLE_QUOTE_LEFT, "'"),
+			Pair.create(T_MACRO_ARGS_STRING, "te$var"),
+			Pair.create(T_PHP_SINGLE_QUOTE_RIGHT, "'"),
 			Pair.create(T_MACRO_TAG_CLOSE, "}"),
 		});
 
@@ -151,6 +150,35 @@ public class LattePhpLexerTest {
 			Pair.create(T_MACRO_ARGS_STRING, "t e"),
 			Pair.create(T_PHP_SINGLE_QUOTE_RIGHT, "'"),
 			Pair.create(T_MACRO_TAG_CLOSE, "}"),
+		});
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testDoubleQuotedString() throws Exception {
+		Lexer lexer = new LatteLexer();
+		lexer.start("{include \"some\"}");
+		assertTokens(lexer, new Pair[] {
+				Pair.create(T_MACRO_OPEN_TAG_OPEN, "{"),
+				Pair.create(T_MACRO_NAME, "include"),
+				Pair.create(T_WHITESPACE, " "),
+				Pair.create(T_PHP_DOUBLE_QUOTE_LEFT, "\""),
+				Pair.create(T_MACRO_ARGS_STRING, "some"),
+				Pair.create(T_PHP_DOUBLE_QUOTE_RIGHT, "\""),
+				Pair.create(T_MACRO_TAG_CLOSE, "}"),
+		});
+
+		lexer.start("{include \"some$var text\"}");
+		assertTokens(lexer, new Pair[] {
+				Pair.create(T_MACRO_OPEN_TAG_OPEN, "{"),
+				Pair.create(T_MACRO_NAME, "include"),
+				Pair.create(T_WHITESPACE, " "),
+				Pair.create(T_PHP_DOUBLE_QUOTE_LEFT, "\""),
+				Pair.create(T_MACRO_ARGS_STRING, "some"),
+				Pair.create(T_MACRO_ARGS_VAR, "$var"),
+				Pair.create(T_MACRO_ARGS_STRING, " text"),
+				Pair.create(T_PHP_DOUBLE_QUOTE_RIGHT, "\""),
+				Pair.create(T_MACRO_TAG_CLOSE, "}"),
 		});
 	}
 
@@ -461,6 +489,21 @@ public class LattePhpLexerTest {
 			Pair.create(T_HTML_CLOSE_TAG_OPEN, "</"),
 			Pair.create(T_TEXT, "a"),
 			Pair.create(T_HTML_TAG_CLOSE, ">"),
+		});
+
+		lexer.start("{link default id => 123}");
+		assertTokens(lexer, new Pair[] {
+			Pair.create(T_MACRO_OPEN_TAG_OPEN, "{"),
+			Pair.create(T_MACRO_NAME, "link"),
+			Pair.create(T_WHITESPACE, " "),
+			Pair.create(T_LINK_DESTINATION, "default"),
+			Pair.create(T_WHITESPACE, " "),
+			Pair.create(T_PHP_IDENTIFIER, "id"),
+			Pair.create(T_WHITESPACE, " "),
+			Pair.create(T_MACRO_ARGS, "=>"),
+			Pair.create(T_WHITESPACE, " "),
+			Pair.create(T_MACRO_ARGS_NUMBER, "123"),
+			Pair.create(T_MACRO_TAG_CLOSE, "}"),
 		});
 	}
 


### PR DESCRIPTION
## Changes

- added new tags {try} {rollback} {ifchanged} {skipIf}
- added new filters |clamp |sort and custom function clamp()
- added support for references to core functions with \, e.g. \current()
- added support for floats, hex, oct, bin and numbers with exponent (issue #123)
- added support for UNPAIRED_ATTR tags (issue #120)
- fixed undefined variable problem in n:for loop (issue #98)
- fixed marked parameters as link (issue #102)
- fixed bug with nested blocks used as n: attributes (issue #109)
- fixed bug in code formatting for AUTO_EMPTY tags (issue #114, #125, #116)
- fixed performance bugs (issue #105, #117)
- fixed bug with double-click behavior in double quoted strings (issue #111)